### PR TITLE
Drop `isl` workaround and `gcc` pinning

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     md5: 4039b7e7845cf0345c87b75a9fc08fb1
 
 build:
-    number: 0
+    number: 1
     skip: true    # [win]
 
 requirements:
@@ -19,7 +19,7 @@ requirements:
         - numpy x.x
         - cython
         - flann
-        - gcc          # [osx]
+        - gcc          # [unix]
     run:
         - python
         - numpy x.x
@@ -27,7 +27,7 @@ requirements:
         - scikit-learn >=0.17
         - pyamg
         - pyflann
-        - libgcc       # [osx]
+        - libgcc       # [unix]
 
 test:
     requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,7 @@ requirements:
         - numpy x.x
         - cython
         - flann
-        - isl 0.12.*   # [osx]
-        - gcc 4.8*     # [osx]
+        - gcc          # [osx]
     run:
         - python
         - numpy x.x
@@ -28,8 +27,7 @@ requirements:
         - scikit-learn >=0.17
         - pyamg
         - pyflann
-        - isl 0.12.*   # [osx]
-        - libgcc 4.8*  # [osx]
+        - libgcc       # [osx]
 
 test:
     requires:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/megaman-feedstock/issues/1

Dropped the `isl` pinning as this shouldn't be needed any more as a hot-fix has been applied to `gcc`. ( https://github.com/ContinuumIO/anaconda-issues/issues/833#issuecomment-228581113 )

Also, remove the pinning of `gcc` and `libgcc`. Not quite sure what purpose that served, but it really shouldn't be needed. Additionally drop `isl` as a run-time dependency. It is only required to build and run `gcc` not distribute `libgcc`.

Finally, ensures `gcc` is used on both OS X and Linux.